### PR TITLE
Assignment: Add new AveragePostsPerUserPerMonth calculator

### DIFF
--- a/app/module/Statistics/src/Calculator/AbstractCalculator.php
+++ b/app/module/Statistics/src/Calculator/AbstractCalculator.php
@@ -56,24 +56,30 @@ abstract class AbstractCalculator implements CalculatorInterface
     }
 
     /**
+     * Helper to check that a post meets the needed criteria and should be
+     * included in calculations.
+     *
      * @param SocialPostTo $postTo
      *
      * @return bool
      */
     protected function checkPost(SocialPostTo $postTo): bool
     {
+        // Post's date is before the given date range
         if (null !== $this->parameters->getStartDate()
             && $this->parameters->getStartDate() > $postTo->getDate()
         ) {
             return false;
         }
 
+        // Post's date is after the given date range
         if (null !== $this->parameters->getEndDate()
             && $this->parameters->getEndDate() < $postTo->getDate()
         ) {
             return false;
         }
 
+        // If none of the above conditions failed, assume the check passed
         return true;
     }
 

--- a/app/module/Statistics/src/Calculator/AveragePostsPerUserPerMonth.php
+++ b/app/module/Statistics/src/Calculator/AveragePostsPerUserPerMonth.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Statistics\Calculator;
+
+use DateTime;
+use SocialPost\Dto\SocialPostTo;
+use Statistics\Dto\StatisticsTo;
+
+/**
+ * Class AveragePostsPerUserPerMonth
+ *
+ * @package Statistics\Calculator
+ */
+class AveragePostsPerUserPerMonth extends AbstractCalculator
+{
+
+    protected const UNITS = 'posts per user';
+
+    /**
+     * @var array<string, int>
+     */
+    private array $totals = [];
+
+    /**
+     * @var array<string, array<string>>
+     */
+    private array $uniqueUsers = [];
+
+     protected function doAccumulate(SocialPostTo $postTo): void
+    {
+        $month = $postTo->getDate()?->format('Y-m') ?? 'unknown';
+        $userId = $postTo->getAuthorId();
+
+        // Collect unique posters for each months
+        if (!isset($this->uniqueUsers[$month])) {
+            $this->uniqueUsers[$month] = [];
+        }
+
+        if (! in_array($userId, $this->uniqueUsers[$month])) {
+            $this->uniqueUsers[$month][] = $userId;
+        }
+
+        // Also count total number of posts for each month
+        $this->totals[$month] = ($this->totals[$month] ?? 0) + 1;
+    }
+
+      protected function doCalculate(): StatisticsTo
+    {
+        $stats = new StatisticsTo();
+
+        // Ensure that the stats come in correct chronological order
+        ksort($this->totals);
+
+        foreach ($this->totals as $monthId => $totalPosts) {
+            // Round to a reasonable amount of decimals
+            $average = round(
+                $totalPosts / count($this->uniqueUsers[$monthId]),
+                    2
+                );
+
+            $monthLabel = (new DateTime($monthId))->format('F Y');
+
+            $child = (new StatisticsTo())
+                ->setName($this->parameters->getStatName())
+                ->setSplitPeriod($monthLabel)
+                ->setValue($average)
+                ->setUnits(self::UNITS);
+
+            $stats->addChild($child);
+        }
+
+        return $stats;
+    }
+}

--- a/app/module/Statistics/src/Calculator/Factory/StatisticsCalculatorFactory.php
+++ b/app/module/Statistics/src/Calculator/Factory/StatisticsCalculatorFactory.php
@@ -4,10 +4,10 @@ namespace Statistics\Calculator\Factory;
 
 use Statistics\Calculator\AbstractCalculator;
 use Statistics\Calculator\AveragePostLength;
+use Statistics\Calculator\AveragePostsPerUserPerMonth;
 use Statistics\Calculator\CalculatorComposite;
 use Statistics\Calculator\CalculatorInterface;
 use Statistics\Calculator\MaxPostLength;
-use Statistics\Calculator\NoopCalculator;
 use Statistics\Calculator\TotalPostsPerWeek;
 use Statistics\Dto\ParamsTo;
 use Statistics\Enum\StatsEnum;
@@ -24,7 +24,7 @@ class StatisticsCalculatorFactory
         StatsEnum::AVERAGE_POST_LENGTH                     => AveragePostLength::class,
         StatsEnum::MAX_POST_LENGTH                         => MaxPostLength::class,
         StatsEnum::TOTAL_POSTS_PER_WEEK                    => TotalPostsPerWeek::class,
-        StatsEnum::AVERAGE_POSTS_NUMBER_PER_USER_PER_MONTH => NoopCalculator::class,
+        StatsEnum::AVERAGE_POSTS_NUMBER_PER_USER_PER_MONTH => AveragePostsPerUserPerMonth::class,
     ];
 
     /**

--- a/app/tests/unit/Calculator/AveragePostsPerUserPerMonthTest.php
+++ b/app/tests/unit/Calculator/AveragePostsPerUserPerMonthTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\unit\Calculator;
+
+use DateTime;
+use Generator;
+use Statistics\Enum\StatsEnum;
+
+/**
+ * Class AveragePostsPerUserPerMonthTest
+ *
+ * @package Tests\unit\Calculator
+ */
+class AveragePostsPerUserPerMonthTest extends CalculatorTestCase
+{
+    protected string $calculatorName = StatsEnum::AVERAGE_POSTS_NUMBER_PER_USER_PER_MONTH;
+
+    /**
+     * @dataProvider averagePostsPerUserPerMonthDataProvider
+     */
+    public function testAverageMonthlyPostsPerUserCalculations(
+        DateTime $start,
+        DateTime $end,
+        int $expectedCount,
+        array $exptectedResults
+    ): void
+    {
+        $this->calculateStats($start, $end);
+
+        $children = $this->results->getChildren();
+
+        // Check that we got correct amount of results
+        $this->assertCount($expectedCount, $children);
+
+        // Also check that results are as expected
+        foreach ($exptectedResults as $i => [$name, $averagePosts]) {
+            $this->assertEquals($name, $children[$i]->getSplitPeriod());
+            $this->assertEquals($averagePosts, $children[$i]->getValue());
+            $this->assertEquals('posts per user', $children[$i]->getUnits());
+
+            next($children);
+        }
+    }
+
+    /**
+     * See `getTestPosts()` method in parent class
+     */
+    public function averagePostsPerUserPerMonthDataProvider(): Generator
+    {
+        yield from [
+            'Whole test dataset (3 months)' => [
+                'start' => new DateTime('Jan 2023'),
+                'end' => new DateTime('Mar 2023'),
+                'result_count' => 3,
+                'results' => [ // [month name, average posts]
+                    ['January 2023',  1.33], // 4 posts, 3 users
+                    ['February 2023', 2], // 2 posts, 1 user
+                    ['March 2023', 1] // 1 post, 1 user
+                ]
+            ],
+            'Smaller timespan (Jan-Feb 2023)' => [
+                'start' => new DateTime('Jan 2023'),
+                'end' => new DateTime('Feb 2023'),
+                'result_count' => 2,
+                'results' => [
+                    ['January 2023',  1.33],
+                    ['February 2023', 2],
+                ]
+            ],
+            'Just one month (Feb 2023)' => [
+                'start' => new DateTime('Feb 2023'),
+                'end' => new DateTime('Feb 2023'),
+                'result_count' => 1,
+                'results' => [
+                    ['February 2023', 2]
+                ]
+            ],
+            'Date interval without overlap to test data' => [
+                'start' => new DateTime('Jan 2020'),
+                'end' => new DateTime('Dec 2020'),
+                'result_count' => 0,
+                'results' => []
+            ],
+        ];
+    }
+}

--- a/app/tests/unit/Calculator/CalculatorTestCase.php
+++ b/app/tests/unit/Calculator/CalculatorTestCase.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\unit\Calculator;
+
+use ArrayObject;
+use DateTime;
+use PHPUnit\Framework\TestCase;
+use SocialPost\Dto\SocialPostTo;
+use Statistics\Dto\ParamsTo;
+use Statistics\Dto\StatisticsTo;
+use Statistics\Service\Factory\StatisticsServiceFactory;
+
+/**
+ * Abstract class CalculatorTestCase.
+ *
+ * @package Tests\unit
+ */
+abstract class CalculatorTestCase extends TestCase
+{
+    protected string $calculatorName;
+
+    protected StatisticsTo $results;
+
+
+    /**
+     * Run the calculations for given time interval and save the resulting stats
+     * into the `$results` property.
+     */
+    protected function calculateStats(DateTime $start, DateTime $end): void
+    {
+        // Normalize the date params to exact month start/end like in ParamsBuilder
+        $start = (clone $start)->modify('first day of this month')->setTime(0, 0, 0);
+        $end = (clone $end)->modify('last day of this month')->setTime(23, 59, 59);
+
+        $params = [
+            (new ParamsTo())
+                ->setStatName($this->calculatorName)
+                ->setStartDate($start)
+                ->setEndDate($end)
+        ];
+
+        // Note: the method needs Traversable, hence regular array isn't enough
+        $postData = new ArrayObject($this->getTestPosts());
+
+        // Run the calculations and save the result for further assertions
+        $statsService = StatisticsServiceFactory::create();
+        $parentStatistics = $statsService->calculateStats($postData, $params);
+        $this->results = $parentStatistics->getChildren()[0];
+    }
+
+
+    /**
+     * Return a simple test dataset of SocialPost DTOs to be used across
+     * different calculation tests.
+     *
+     * As of now the set contains 7 posts for 3 different users:
+     * - Alice: 4 posts (Jan 23 * 2, Feb 23 * 2)
+     * - Bob: 2 posts (Jan 23, Mar 23)
+     * - John: 1 post (Jan 23)
+     *
+     * @TODO: e.g. some kind of fixture file could be more convenient for this?
+     *
+     * @return array<SocialPostTo>
+     */
+    protected function getTestPosts(): array
+    {
+        // Define the different authors here as tuples to avoid repetition
+        $authors = [
+            ['user001', 'Alice'],
+            ['user002', 'Bob'],
+            ['user055', 'John'],
+        ];
+
+        // Define data as plain array
+        $posts = [
+            // January 2023 (4 posts total)
+            [
+                'id' => 'post001',
+                'date' => '2023-01-06 01:23:45',
+                'author' => 0,
+                'text' => 'Lorem ipsum' // 11 chars
+            ],
+            [
+                'id' => 'post002',
+                'date' => '2023-01-07 02:34:00',
+                'author' => 0,
+                'text' => 'Dolor sit amet' // 14 chars
+            ],
+            [
+                'id' => 'post003',
+                'date' => '2023-01-11 11:11:11',
+                'author' => 1,
+                'text' => 'Hello World!' // 12 chars
+            ],
+            [
+                'id' => 'post004',
+                'date' => '2023-01-31 12:12:12',
+                'author' => 2,
+                'text' => 'Yeehaw, this is the January record' // 34 chars
+            ],
+            // February 2023 (2 posts total)
+            [
+                'id' => 'post005',
+                'date' => '2023-02-05 13:13:13',
+                'author' => 0,
+                'text' => 'Who reads these anyway?' // 23 chars
+            ],
+            [
+                'id' => 'post006',
+                'date' => '2023-02-12 14:14:14',
+                'author' => 0,
+                'text' => 'Hello world again' // 17 chars
+            ],
+            // March 2023 (1 post total)
+            [
+                'id' => 'post007',
+                'date' => '2023-03-04 20:20:20',
+                'author' => 1,
+                'text' => 'The longest text of them all with fifty characters'
+            ],
+        ];
+
+        // Convert the array items to SocialPost DTOs
+        return array_map(
+            function ($item) use ($authors) {
+                return (new SocialPostTo())
+                    ->setId($item['id'])
+                    ->setDate(new DateTime($item['date']))
+                    ->setAuthorId($authors[$item['author']][0])
+                    ->setAuthorName($authors[$item['author']][1])
+                    ->setType('status') // Hard-coded, currently not actually relevant in tests
+                    ->setText($item['text']);
+            },
+           $posts
+        );
+    }
+}

--- a/app/tests/unit/Calculator/MaxPostLengthTest.php
+++ b/app/tests/unit/Calculator/MaxPostLengthTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\unit\Calculator;
+
+use DateTime;
+use Generator;
+use Statistics\Enum\StatsEnum;
+
+/**
+ * Class MaxPostLengthTest.php
+ *
+ * @package Tests\unit\Calculator
+ */
+class MaxPostLengthTest extends CalculatorTestCase
+{
+    protected string $calculatorName = StatsEnum::MAX_POST_LENGTH;
+
+    /**
+     * @dataProvider maxPostLengthDataProvider
+     */
+    public function testAverageMonthlyPostsPerUserCalculations(
+        DateTime $start,
+        DateTime $end,
+        float $expectedResult
+    ): void
+    {
+        $this->calculateStats($start, $end);
+        $this->assertEquals($expectedResult, $this->results->getValue());
+    }
+
+    /**
+     * See `getTestPosts()` method in parent class
+     */
+    public function maxPostLengthDataProvider(): Generator
+    {
+        yield from [
+            'All test posts' => [
+                'start' => new DateTime('Jan 2023'),
+                'end' => new DateTime('Mar 2023'),
+                'result' => 50, // Longest message in whole dataset
+            ],
+            'January 2023' => [
+                'start' => new DateTime('Jan 2023'),
+                'end' => new DateTime('Jan 2023'),
+                'result' => 34 // Longest text in January
+            ],
+            'February 2023' => [
+                'start' => new DateTime('Feb 2023'),
+                'end' => new DateTime('Feb 2023'),
+                'result' => 23 // Longest text in February
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
As per assignment text, add new calculator implementation that calculates average number of posts per user for each month. 

Also added some tests for the calculations: 
- Abstract base test class which makes testing various calculators a bit more convenient
- Tests for the newly added AveragePostsPerUserPerMonth calculator
- Also tests for the existing MaxPostLength calculator

As a bonus, added a few logic-clarifying comments to existing code (I got a feeling that this codebase could benefit for more comments)
